### PR TITLE
Add workaround for broken text editor

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -4,6 +4,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Content Manager</title>
+    <style>
+      /* Workaround for text editor https://github.com/decaporg/decap-cms/issues/5092 */
+      [data-slate-editor] { 
+        -webkit-user-modify: read-write !important; 
+      }
+    </style>
     <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
   </head>
   <body>


### PR DESCRIPTION
The text editor will snap the cursor to the end of a line of text in chrome. This impacts both markdown and rich text editors.

More info here: https://github.com/decaporg/decap-cms/issues/5092